### PR TITLE
Update from pyPdf 1.13 to PyPDF2 1.27.5

### DIFF
--- a/cloudooo/handler/pdf/handler.py
+++ b/cloudooo/handler/pdf/handler.py
@@ -36,8 +36,8 @@ from cloudooo.util import logger, parseContentType
 from subprocess import Popen, PIPE
 from tempfile import mktemp
 
-from pyPdf import PdfFileWriter, PdfFileReader
-from pyPdf.generic import NameObject, createStringObject
+from PyPDF2 import PdfFileWriter, PdfFileReader
+from PyPDF2.generic import NameObject, createStringObject
 
 class Handler(object):
   """PDF Handler is used to handler inputed pdf document."""

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
           'zope.interface',
           'PasteDeploy',
           'PasteScript[WSGIUtils]',
-          'pyPdf',
+          'pypdf2==1.27.5',
           'psutil>=3.0.0',
           'lxml',
           'python-magic',


### PR DESCRIPTION
Hello.

We have been using cloudooo at my company (Libriciel SCOP, providing open source software for public administration and local authorities in France) for quite some time now, even though we only made [1 contribution so far](https://github.com/Nexedi/cloudooo/pull/3). We are using it only for document conversion, mainly from ODT to PDF (no audio or video).

## General context

We are having some problems now because python 2 end of life was [january 1, 2020](https://www.python.org/doc/sunset-python-2/) and cloudooo is only working with python 2.

Some other problems we face are about (it does not really matter in this PR, its mainly for the context)

- tags (last official release was 1.2.4 on May 19 2012)
- dependency version pinning

My company needs python 3 support and we could do that by ourselves, either

1. by providing other pull request(s) to the cloudooo project if you are interested (the aim is to have python 2 and python 3 compatibility in the first place)
2. by completely forking the cloudooo project and renaming it to something like lscloudooo to avoid confusion (while still keeping the open source idea)

Please, consider this pull request as a first contact and some kind of proof of concept about a possible collaboration on a python 2 and 3 compatibility.

## About this PR

I noticed that you were using pypdf which is only python 2 and also that pypdf2 existed with python 2 and python 3 support. As I commented in [my issue](https://github.com/jmjjg/cloudooo/issues/3), pypdf2 uses the same API (at least the functions and classes used in cloudooo, I made a quick test that you can see in the [second comment of my issue](https://github.com/jmjjg/cloudooo/issues/3#issuecomment-1318667980)).

I would have launched the unit tests, but I struggled (not for long, I confess) and could not understand how to launch them all (it seems you have more than 200 tests). Maybe you could provide me some information about that ?

Also, I tried to register on [your company gitlab](https://lab.nexedi.com/) since I understood that the repository here on github is only a mirror, but I got the error `Email domain is not authorized for sign-up` (I was using the email address `firstname.lastname@mycompany.fr`).

Sincerely yours,
Christian BUFFIN
Methods manager and senior developer at [Libriciel SCOP](https://www.libriciel.fr/)